### PR TITLE
Add labels to FilamentTable and FilamentForm templates

### DIFF
--- a/src/main/static/templates/crud/views/filament/templates/FilamentForm.vemtl
+++ b/src/main/static/templates/crud/views/filament/templates/FilamentForm.vemtl
@@ -1,8 +1,10 @@
 <% const inputFormData = input.filamentSettings.formData %>
 <% const [inlineRules, individualRules] = input.getRulesForFilamentTemplate() %>
 <% const inputTypeIs = (type) => inputFormData.inputType === type %>
+<% const inputLabel = input.isBelongsTo() ? `'${capitalCase(input.relationship.name)}'` : this.helpers.toTranslatableFormat(input.label) %>
 
 <$ pascalCase(inputFormData.inputType) $>::make('<$ input.name $>')
+    ->label(<$ inputLabel $>)
     <###>
     <% if(inlineRules.length) { %>
         ->rules([<$ inlineRules.join(', ') $>])

--- a/src/main/static/templates/crud/views/filament/templates/FilamentTable.vemtl
+++ b/src/main/static/templates/crud/views/filament/templates/FilamentTable.vemtl
@@ -1,7 +1,9 @@
 <% const inputColumnData = input.filamentSettings.columnData %>
 <% const columnName = !input.isBelongsTo() ? input.name : `${input.relationship.name}.${input.relationship.relatedModel.table.getLabelColumnName()}` %>
+<% const inputLabel = input.isBelongsTo() ? `'${capitalCase(input.relationship.name)}'` : this.helpers.toTranslatableFormat(input.label) %>
 <###>
 <$ pascalCase(inputColumnData.columnType) $>::make('<$ columnName $>')
+    ->label(<$ inputLabel $>)
     <% if(input.isImage() && input.filamentSettings.formData.disk) { %>
         ->disk('<$ input.filamentSettings.formData.disk $>')
     <% } %>


### PR DESCRIPTION
This commit introduces the `->label()` method to both the FilamentTable and FilamentForm templates. The label is dynamically determined based on whether the input is a relationship or a direct attribute, enhancing the clarity and usability of the generated forms and tables.