### PR TITLE
Remove 15-table limitation for full opensource release

### DIFF
--- a/src/renderer/views/ProjectMainView.vue
+++ b/src/renderer/views/ProjectMainView.vue
@@ -218,13 +218,13 @@
     }
 
     const checkLicenseAndTablesCount = () : boolean => {
-        if(!window.licenseIsActive() && projectStore.project.tables.length > 15) {
+       /* if(!window.licenseIsActive() && projectStore.project.tables.length > 15) {
             window.showLicenseModal(
                 "This project has more than 15 tables (including Laravel default tables). Please activate your license to generate code."
             )
 
             return false
-        }
+        }*/
 
         return true
     }

--- a/src/renderer/views/components/ProjectSchema/SchemaHeader.vue
+++ b/src/renderer/views/components/ProjectSchema/SchemaHeader.vue
@@ -218,10 +218,10 @@ import ReservedKeywords from '@Common/models/services/ReservedKeywords'
     const showTableModal = (): void => {
         const currentTablesCount = projectStore.project.tables.length
 
-        if(!window.licenseIsActive() && currentTablesCount > 15) {
+        /* if(!window.licenseIsActive() && currentTablesCount > 15) {
             window.showLicenseModal("This project has more than 15 tables (including Laravel default tables). Please activate your license to add unlimited tables.")
             return
-        }
+        } */
 
         reset()
         


### PR DESCRIPTION
## 🎯 Objetivo

Remove a limitação de 15 tabelas do Vemto, tornando o projeto totalmente 
opensource e permitindo uso ilimitado do gerador de código.

Esta mudança foi solicitada pelo mantenedor do projeto (@TiagoSilvaPereira).

## 📝 Mudanças Realizadas

### Arquivos Modificados

1. **src/renderer/views/components/ProjectSchema/SchemaHeader.vue**
   - Comentadas linhas 221-224
   - Remove verificação de licença ao adicionar novas tabelas
   
2. **src/renderer/views/ProjectMainView.vue**
   - Comentadas linhas 221-227
   - Remove verificação de licença ao gerar código

### Detalhes Técnicos

- As verificações foram comentadas (não removidas) para facilitar 
  futuras referências ou reversões se necessário
- Mantém todo o código de licença intacto para features que ainda 
  requerem licença (AI, auto-updates, etc.)
- Não afeta nenhuma outra funcionalidade do sistema

## ✅ Funcionalidades Liberadas

Com este PR, usuários poderão:
- ✅ Criar quantas tabelas quiserem
- ✅ Gerar código sem limitações
- ✅ Usar todas as funcionalidades do editor de schema
- ✅ Gerar migrations, models, CRUDs, APIs ilimitadamente

## ⚠️ Funcionalidades que Ainda Requerem Licença

Esta mudança **não afeta** recursos que dependem da infraestrutura do Vemto:
- AI features
- Auto-updates automáticos
- Builds pré-compilados oficiais

## 🧪 Testes Realizados

- [x] Testado criação de projeto com 20+ tabelas
- [x] Testado geração de código completa (migrations, models, CRUDs)
- [x] Verificado que não aparece modal de licença
- [x] Testado em modo desenvolvimento (`yarn dev:fast`)
- [x] Verificado que recursos de licença não foram afetados
- [x] Editor de schema funciona normalmente
- [x] Todos os testes passam (`yarn test`)